### PR TITLE
Add `libcgillespy3d` build and installation to setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
+# Building from Source
+The core C++ library, `libcgillespy3d`, can be found in the `libcGillesPy3D/` directory. It is built using a custom [SCons](https://scons.org/documentation.html) build.
+
+## Building the Core C++ Library
+From the root-level directory, ensure that SCons is installed and run the following command:
+```sh
+scons -C libcGillesPy3D/
+# to clean the environment:
+scons -c -C libcGillesPy3D/
+```
+
+The build output is placed in the `libcGillesPy3D/lib` directory, which includes any static libraries required by dependencies, as well as a SWIG-generated `libcgillespy3d` package. Adding the `lib` directory to your `PATH`/`PYTHONPATH` will work as a manual way to add the `libcgillespy3d` library.
+
+## Building the Python Extension
+Before building the Python extension, you must first [build the core C++ library](#building-the-core-c-library).
+
+From the root-level directory, install the library using `pip`:
+```sh
+pip install .
+```
+
+For development purposes, you may want to use an editable install to have changes to Python scripts reflect automatically in the environment:
+```sh
+pip install -e .
+# when the C++ extension is modified, rerun the command to rebuild
+# or, you can use the (technically deprecated) method of manually running the setup script:
+python3 setup.py build_ext --inplace
+# to clean the python build files:
+python3 setup.py clean --all
+```
+
+However, most versions of `pip` cannot account for external extension packages and will break if attempting to do an editable install alone. There are two fixes for this to get extensions to load correctly using an editable install:
+1. Treat the `libcgillespy3d` as an external package by manually configuring it onto your `PYTHONPATH`
+```sh
+# manual
+export PYTHONPATH=$PYTHONPATH:$PWD/libcGillesPy3D/lib
+# using conda
+conda develop libcGillesPy3D/lib
+```
+2. Use the [PEP 517](https://peps.python.org/pep-0517/) install method (which will be standard in `pip` at some point in the future):
+```sh
+pip install -e . --use-pep517 # rerun to rebuild the extension
+```
+3. Add the extension build directory as a user site package:
+```sh
+mkdir -p $(python3 -m site --user-site) && echo "$PWD/libcGillesPy3D/lib" > "$(python3 -m site --user-site)/libcgillespy3d.pth"
+```
+
 Examples:

--- a/gillespy3d/core/model.py
+++ b/gillespy3d/core/model.py
@@ -33,7 +33,7 @@ from gillespy3d.core.timespan import TimeSpan
 from gillespy3d.solvers.build_expression import BuildExpression
 from gillespy3d.core.error import ModelError
 
-import libcgillespy3d
+from libcgillespy3d import libcgillespy3d
 
 
 class Model(libcgillespy3d.Model):

--- a/gillespy3d/core/parameter.py
+++ b/gillespy3d/core/parameter.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from gillespy3d.core.error import ParameterError
 
-import libcgillespy3d
+from libcgillespy3d import libcgillespy3d
 
 class Parameter(libcgillespy3d.Parameter):
     """

--- a/gillespy3d/core/reaction.py
+++ b/gillespy3d/core/reaction.py
@@ -23,7 +23,7 @@ from gillespy3d.core.species import Species
 from gillespy3d.core.parameter import Parameter
 from gillespy3d.core.error import ReactionError
 
-import libcgillespy3d
+from libcgillespy3d import libcgillespy3d
 
 class Reaction(libcgillespy3d.Reaction):
     """

--- a/gillespy3d/core/species.py
+++ b/gillespy3d/core/species.py
@@ -16,7 +16,7 @@
 from gillespy3d.core.parameter import Parameter
 from gillespy3d.core.error import SpeciesError
 
-import libcgillespy3d
+from libcgillespy3d import libcgillespy3d
 
 
 class Species(libcgillespy3d.Species):

--- a/libcGillesPy3D/SConstruct
+++ b/libcGillesPy3D/SConstruct
@@ -1,21 +1,21 @@
-import distutils.sysconfig
+import sysconfig
 import os
 
 
 # Make sure python3 dev headers are installed
 # On Ubuntu, python3-dev (might need version-specific, e.g. python3.11-dev, which might require adding new repos)
 # On Fedora, python3-devel (might need version-specific, e.g. python3.11-devel)
-pyinc = distutils.sysconfig.get_python_inc()
+
+cmd_opts = Variables(None, ARGUMENTS)
+cmd_opts.Add(PathVariable("PYTHONINC", help="Path to Python development header include directory", default=sysconfig.get_path("include")))
+cmd_opts.Add("CC")
+cmd_opts.Add("CFLAGS")
+cmd_opts.Add("CXX")
+cmd_opts.Add("CXXFLAGS")
+cmd_opts.Add("LD")
 
 env = Environment(
-    CXXFLAGS=[
-        "-std=c++17",
-        "-fPIC",
-    ],
-    TOOLS=[
-        "default",
-        "swig",
-    ],
+    variables=cmd_opts,
     SWIGOUTDIR=Dir("lib/libcgillespy3d"),
     CPPPATH=[
         Dir("include"),
@@ -24,14 +24,20 @@ env = Environment(
         Dir("external/Sundials/src"),
         Dir("external/Sundials/cmake-build/default/include"),
         Dir("external/Sundials/src/sundials"),
-        pyinc,
+        Dir("${PYTHONINC}"),
     ],
     LIBPATH=[
         Dir("obj"),
         Dir("obj/external/Sundials"),
     ],
-    ENV=os.environ,
 )
+
+env.Append(TOOLS=["swig"])
+env.MergeFlags({
+    "CXXFLAGS": [
+        "-std=c++17",
+    ],
+})
 
 # Send dependency build files to obj/ subfolders
 # From this point on, refer to all source files as being relative to the build directory

--- a/libcGillesPy3D/SConstruct
+++ b/libcGillesPy3D/SConstruct
@@ -16,7 +16,7 @@ env = Environment(
         "default",
         "swig",
     ],
-    SWIGOUTDIR=Dir("bin"),
+    SWIGOUTDIR=Dir("lib"),
     CPPPATH=[
         Dir("include"),
         Dir("external/ANN/include"),
@@ -33,8 +33,6 @@ env = Environment(
     ENV=os.environ,
 )
 
-env.Execute(Mkdir("bin"))
-
 # Send dependency build files to obj/ subfolders
 # From this point on, refer to all source files as being relative to the build directory
 # SCons will automagically map your build-relative file to the real path
@@ -42,21 +40,17 @@ VariantDir("obj/src", "src", duplicate=False)
 VariantDir("obj/external", "external", duplicate=False)
 VariantDir("obj/include", "include", duplicate=False)
 
-libcgillespy3d = SConscript("obj/src/SConscript", exports=["env"])
+cgillespy3d = SConscript("obj/src/SConscript", exports=["env"])
 sundials = SConscript("obj/external/Sundials/SConscript", exports=["env"])
 
-py_lib = env.SharedLibrary("bin/_libcgillespy3d",
-    [
-        "obj/include/libcgillespy3d.i",
-    ],
-    LIBS=[libcgillespy3d, sundials],
-    SHLIBPREFIX="",
-    SHLIBSUFFIX=(".so" if os.name not in ['nt'] else ".pyd"),
+libcgillespy3d = env.StaticLibrary(
+    "lib/cgillespy3d",
+    ["obj/include/libcgillespy3d.i", *cgillespy3d, *sundials],
     SWIGFLAGS=[
         "-c++",
         "-python",
         "-features",
         "autodoc",
-    ]
+    ],
+    SWIGCXXFILESUFFIX="_wrap.cpp",
 )
-env.Clean(py_lib, Dir("bin/__pycache__"))

--- a/libcGillesPy3D/SConstruct
+++ b/libcGillesPy3D/SConstruct
@@ -16,7 +16,7 @@ env = Environment(
         "default",
         "swig",
     ],
-    SWIGOUTDIR=Dir("lib"),
+    SWIGOUTDIR=Dir("lib/libcgillespy3d"),
     CPPPATH=[
         Dir("include"),
         Dir("external/ANN/include"),

--- a/libcGillesPy3D/external/Sundials/SConscript
+++ b/libcGillesPy3D/external/Sundials/SConscript
@@ -29,11 +29,11 @@ nvector = SConscript("src/nvector/SConscript", exports=["env"])
 sunmatrix = SConscript("src/sunmatrix/SConscript", exports=["env"])
 sunnonlinsol = SConscript("src/sunnonlinsol/SConscript", exports=["env"])
 
-sundials = env.StaticLibrary("sundials", [
+sundials = [
     cvode,
     sundials,
     nvector,
     sunmatrix,
-])
+]
 
 Return("sundials")

--- a/libcGillesPy3D/src/SConscript
+++ b/libcGillesPy3D/src/SConscript
@@ -1,6 +1,6 @@
 Import("env")
 
-libcgillespy3d = env.Library("cgillespy3d", [
+libcgillespy3d = env.Object([
     "model.cpp",
     "model_context.cpp",
     "reaction.cpp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=61.0","scons>=4.7.0"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,9 @@ from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.command.bdist_egg import bdist_egg
 from setuptools.command.easy_install import easy_install
+from setuptools import Extension
+from setuptools.command.build_py import build_py
+from setuptools.command.build_ext import build_ext
 import os
 from os import path
 
@@ -65,6 +68,28 @@ with open(path.join(SETUP_DIR, 'gillespy3d/__version__.py')) as f:
         version[setting[0].strip()] = setting[1].strip().replace("'", '')
 
 
+# Configure and compile C extension
+libcgillespy3d = Extension(
+    name="libcgillespy3d._libcgillespy3d",
+    language="c++",
+    sources=[
+        "libcGillesPy3D/obj/include/libcgillespy3d_wrap.cpp",
+    ],
+    include_dirs=[
+        "libcGillesPy3D/include",
+        "libcGillesPy3D/external/ANN/include",
+        "libcGillesPy3D/external/Sundials/include",
+        "libcGillesPy3D/external/Sundials/cmake-build/default/include",
+    ],
+    library_dirs=[
+        "libcGillesPy3D/lib",
+    ],
+    libraries=[
+        "cgillespy3d",
+    ],
+)
+
+
 # Finally, define our namesake.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -86,10 +111,12 @@ setup(name                 = version['__title__'].lower(),
           "Tracker": "https://github.com/GillesPy3D/GillesPy3D/issues",
           "Source" : "https://github.com/GillesPy3D/GillesPy3D",
       },
-      packages             = find_packages('.'),
+      packages             = find_packages('.') + ['libcgillespy3d'],
+      package_dir={'libcgillespy3d': 'libcGillesPy3D/lib'},
       include_package_data = True,
       install_requires     = reqs,
 
+      ext_modules=[libcgillespy3d],
       classifiers      = [
           'Development Status :: 5 - Production/Stable',
           'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(name                 = version['__title__'].lower(),
           "Source" : "https://github.com/GillesPy3D/GillesPy3D",
       },
       packages             = find_packages('.') + ['libcgillespy3d'],
-      package_dir={'libcgillespy3d': 'libcGillesPy3D/lib'},
+      package_dir={'libcgillespy3d': 'libcGillesPy3D/lib/libcgillespy3d'},
       include_package_data = True,
       install_requires     = reqs,
 


### PR DESCRIPTION
This change will move the work of building the extension into the `setup.py` script, such that the SCons build is only responsible for the library itself and SWIG wrappers. The actual extension (the `.so`/`.pyd` library) will be handled by setuptools.
- Implements work needed for publishing to PyPi and Anaconda
- Completes cross-platform build compatibility for extension code

# Changes
- Modified SCons build to separate extension builds from library builds
  - Outputs SWIG wrapper file(s) and static libraries ONLY
- Updated `setup.py` to depend on output of SCons library build
- Made `libcgillespy3d` into a root-level package rather than a single script
  - Right now this means that the actual SWIG entrypoint is `libcgillespy3d.libcgillespy3d` but this can be moved around
  - Having this split might seem weird right now, but it will be useful if (when?) we split the C library into separate SWIG modules

# TODO
- [x] Update references to `libcgillespy3d` -> `libcgillespy3d.libcgillespy3d`
- [ ] Integrate SCons build as (optional) step in `setup.py`
- [x] Parameterize SCons script
  - [x] Accept CPU architecture and platform; pass in from `setup.py`
  - [x] Accept Python development header path; pass in from `setup.py`